### PR TITLE
fix: avoid unintentional scoping of `this` (fix #13)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export default (opts?: Options) => {
   // default appendToBody true
   const appendToBody = opts?.appendToBody === undefined ? true : opts.appendToBody
   return {
-    toClipboard(text: string, container?: HTMLElement) {
+    toClipboard: (text: string, container?: HTMLElement) => {
       return new Promise((resolve, reject) => {
         // make fake element
         const fakeEl = document.createElement('button')


### PR DESCRIPTION
避免模糊不清的 `this` 作用域, `toClipboard` 方法并不需要使用 `this`。