### PR TITLE
remove "type": "module" from package.json (fix #11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "clipboard",
     "clipboard.js"
   ],
-  "type": "module",
   "main": "dist/cjs/index.js",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Solves issue #11:
`ReferenceError: exports is not defined in ES module scope This file is being treated as an ES module because it has a '.js' file extension and '/home/jesman/Projects/_Frontend/marketplace-customer-account-v1/node_modules/vue-clipboard3/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.`